### PR TITLE
Add runtime feature to bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ repository = "https://github.com/nickray/littlefs2-sys"
 cty = "0.2.1"
 
 [build-dependencies]
-bindgen = { version = "0.65.1", default-features = false }
+bindgen = { version = "0.65.1", default-features = false, features = [
+    "runtime",
+] }
 cc = "1"
 
 [features]


### PR DESCRIPTION
This is basically a cherrypick of https://github.com/trussed-dev/littlefs2-sys/commit/a2cc6720e2a36dd1af17aadd0d4f2c55ec79ebd2.

Fixes `thread 'main' panicked at 'a libclang shared library is not loaded on this thread'` errors.